### PR TITLE
feat✨ : signal 상태별로 나타내기 🟢 🔴

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import type { NextPage } from 'next'
 import Head from 'next/head'
 import { useEffect, useState } from 'react'
 import styles from '../styles/Home.module.css'
+import placeSignal from '../utils/placeSignal';
 
 interface position {
   lat: number,
@@ -35,33 +36,11 @@ const Home: NextPage = () => {
         phase,
       }
     });
-    
+
     positions.forEach(position => {
-      //const signalContent = `<div class="signal"></div>`;
-      const signalContent = document.createElement("div");
-      signalContent.classList.add("signal");
       Object.keys(position.phase).forEach(direction => {
-        // 여기서 함수 만들기. 신호등 위치 받고, 받은 위치와 위도 경도 이용해서 customOverlay sjgrl
-        if (direction.includes("se")) {
-          const content = document.createElement("div");
-          content.classList.add("se");
-          signalContent.append(content);
-        }
-
-        if (direction.includes("sw")) {
-          const content = document.createElement("div");
-          content.classList.add("sw");
-          signalContent.append(content);
-        }
+        placeSignal(position, direction, position.phase[direction], map);
       });
-
-      const signalPoint = new window.kakao.maps.CustomOverlay({
-        position: position.latlng,
-        content: signalContent,
-        map,
-      });
-      
-      signalPoint.setMap(map);
     });
   }, [aroundPositions]);
 
@@ -72,7 +51,7 @@ const Home: NextPage = () => {
         body: JSON.stringify(myPosition),
       });
       const response = await data.json();
-console.log(response);
+
       setAroundPositions(response);
     }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -70,50 +70,6 @@ table {
 	}
 }
 
-.center {
-	position: relative;
-}
-
-.se {
-	position: absolute;
-	top: .1%;
-	left: .1%;
-
-	width: 15px;
-	height: 15px;
-  margin: 15px;
-  border-style: none;
-  border-radius: 50%;
-  background: purple;
-  cursor: pointer;
-  user-select: none;
-
-  animation-name: signal;
-	animation-duration: 1.5s;
-	animation-iteration-count: infinite;
-	animation-timing-function: linear;
-}
-
-.sw {
-	position: absolute;
-	top: 10px;
-	right: 10px;
-
-	width: 15px;
-	height: 15px;
-  margin: 15px;
-  border-style: none;
-  border-radius: 50%;
-  background: pink;
-  cursor: pointer;
-  user-select: none;
-
-  animation-name: signal;
-	animation-duration: 1.5s;
-	animation-iteration-count: infinite;
-	animation-timing-function: linear;
-}
-
 .signal {
 	position: relative;
 	width: 15px;

--- a/utils/placeSignal.ts
+++ b/utils/placeSignal.ts
@@ -1,0 +1,74 @@
+interface phase {
+  [index: string]: string
+}
+
+interface position {
+  title: string;
+  latlng: any;
+  phase: phase;
+}
+
+export default function placeSignal(position: position, direction: string, phase: string, map: any) {
+  const earth = 6378.137;
+  const pi = Math.PI;
+  const m = (1 / ((2 * pi / 360) * earth)) / 1000;
+  const cos = Math.cos;
+  let latlng
+
+  if (direction.includes("nt")) {
+    const newLat = position.latlng.getLat() + (10 * m);
+    latlng = new window.kakao.maps.LatLng(newLat, position.latlng.getLng());
+  }
+
+  if (direction.includes("et")) {
+    const newLng = position.latlng.getLng() + (10 * m) / cos(position.latlng.getLat() * (pi / 180));
+    latlng = new window.kakao.maps.LatLng(position.latlng.getLat(), newLng);
+  }
+
+  if (direction.includes("st")) {
+    const newLat = position.latlng.getLat() + (-10 * m);
+    latlng = new window.kakao.maps.LatLng(newLat, position.latlng.getLng());
+  }
+
+  if (direction.includes("wt")) {
+    const newLng = position.latlng.getLng() + (-10 * m) / cos(position.latlng.getLat() * (pi / 180));
+    latlng = new window.kakao.maps.LatLng(position.latlng.getLat(), newLng);
+  }
+
+  if (direction.includes("ne")) {
+    const newLat = position.latlng.getLat() + (10 * m);
+    const newLng = position.latlng.getLng() + (10 * m) / cos(position.latlng.getLat() * (pi / 180));
+    latlng = new window.kakao.maps.LatLng(newLat, newLng);
+  }
+
+  if (direction.includes("nw")) {
+    const newLat = position.latlng.getLat() + (10 * m);
+    const newLng = position.latlng.getLng() + (-10 * m) / cos(position.latlng.getLat() * (pi / 180));
+    latlng = new window.kakao.maps.LatLng(newLat, newLng);
+  }
+
+  if (direction.includes("se")) {
+    const newLat = position.latlng.getLat() + (-10 * m);
+    const newLng = position.latlng.getLng() + (10 * m) / cos(position.latlng.getLat() * (pi / 180));
+    latlng = new window.kakao.maps.LatLng(newLat, newLng);
+  }
+
+  if (direction.includes("sw")) {
+    const newLat = position.latlng.getLat() + (-10 * m);
+    const newLng = position.latlng.getLng() + (-10 * m) / cos(position.latlng.getLat() * (pi / 180));
+    latlng = new window.kakao.maps.LatLng(newLat, newLng);
+  }
+
+  const content = document.createElement("div");
+  content.classList.add("signal");
+
+  if (phase.includes("stop")) content.classList.add("off");
+
+  const point = new window.kakao.maps.CustomOverlay({
+    position: latlng,
+    content,
+    map,
+  });
+
+  point.setMap(map);
+}


### PR DESCRIPTION
## Complete

* 중심 위도 경도 기준으로 신호등 8방위에 맞춰서 위치시키기
* 현재 상태에 맞는 색 나타내기

### 해결했던 문제
* API 데이터가 신호등 위치를 알려주는 위도 경도를 기준으로 8방위에 위치한 신호등 정보를 제공해주는데, 처음에는 중심을 기준으로 px로 움직여서 나타내려고 했다.
* px로 구현할 경우에는 지도를 축소할 경우 완전히 다른 위치에 나타나게 된다.
* 화면 비율이나 다른 방법들을 고민하다가 중심 위도 경도를 기준으로 8방위로 10미터 움직인 위도와 경도를 구해서 표시하는 방법을 택했다.
* 위도와 경도를 기준으로 m만큼 이동한 것을 계산하는데 참고했던 [레퍼런스](* http://www.movable-type.co.uk/scripts/latlong.html) 로 도움을 받았다. + stackoverflow
* 딱 정확하진 않지만 얼추 비슷하게 위치를 나타냈다.

#### 삽질 ⛏
* ``` kakao.maps.LatLng``` 에서 값이 LA, MA로 반환됐다. 
* LA는 latitude, MA는 Longitude라고 생각하고 신호등 위치를 나타냈는데, 계속 나타나지 않았다.
* 디버깅하면서 보니까, lat값이 127, lng값이 34 이렇게 되어있었다.
* 이상하다고 생각하고 수정전의 값이랑 비교해보니까 둘의 위치가 바뀐 것으로 확인했다.
* 그런데 분명히 위 로직에서는 바뀌는 곳이 없는데 왜그런지 찾아봤다.
* LA가 latitude, MA가 Lomgitude를 나타내는 값이 아니었다. 
* 공식 문서처럼 ```kakao.maps.LatLng.getLat(), kakao.maps.LatLng.getLng()```로 값을 구해야 안전하고 정확했다.
* 임의로 생각하고 짐작말고, 공식문서 잘읽자...