### PR TITLE
refactor 🧹: Recoil 도입, feat ✨:  유저 위치로 이동, 지도 중심 주변 2km만 나타내기

### DIFF
--- a/Components/SignalList.tsx
+++ b/Components/SignalList.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
 import React, { FC, useEffect, useState } from "react";
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { translateDirection, translatePhase } from '../utils/signalUtils';
-import aroundSignalsAtom from '../recoil/aroundSignals/atom';
+import { distanceAtom } from '../recoil/aroundSignals/atom';
 import placeSignal from '../utils/placeSignal';
+import signalWithCalculatedDistance from '../recoil/aroundSignals/withCalculated';
 
 interface ContainerProps {
   isActive: boolean;
@@ -95,7 +96,7 @@ const ItemTitle = styled.span`
 
 const ItemDetails = styled.div``;
 
-interface signal {
+export interface signal {
   title: string,
   timing: {[index: string]: number},
   phase: {[index: string]: string},
@@ -111,14 +112,15 @@ interface ranges {
 }
 
 export const SignalList: FC<Props> = ({ map }) => {
+  const aroundSignals = useRecoilValue(signalWithCalculatedDistance);
+  const setDistance = useSetRecoilState(distanceAtom);
+  const [isActive, setIsActive] = useState<boolean>(false);
   const [ranges, setRanges] = useState<ranges>({
     0.5: true,
     1: false,
     1.5: false,
     2: false
   });
-  const [isActive, setIsActive] = useState<boolean>(false);
-  const aroundSignals = useRecoilValue(aroundSignalsAtom);
 
   const handleRange = (e: React.BaseSyntheticEvent) => {
     const curRange = e.target.id;
@@ -127,6 +129,7 @@ export const SignalList: FC<Props> = ({ map }) => {
 
     const prevRange = Object.keys(ranges).find(range => ranges[range]);
 
+    setDistance(curRange);
     setRanges(prev => {
       const updatedRanges = {...prev};
       updatedRanges[prevRange as string] = false;

--- a/Components/SignalList.tsx
+++ b/Components/SignalList.tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled';
 import React, { FC, useEffect, useState } from "react";
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState, useRecoilState } from 'recoil';
 import { translateDirection, translatePhase } from '../utils/signalUtils';
 import { distanceAtom } from '../recoil/aroundSignals/atom';
 import placeSignal from '../utils/placeSignal';
 import signalWithCalculatedDistance from '../recoil/aroundSignals/withCalculated';
+import myPositionState from '../recoil/myPosition/atom';
+import mapPositionAtom from '../recoil/mapPosition/atom';
 
 interface ContainerProps {
   isActive: boolean;
@@ -112,8 +114,10 @@ interface ranges {
 }
 
 export const SignalList: FC<Props> = ({ map }) => {
+  const myPosition = useRecoilValue(myPositionState);
   const aroundSignals = useRecoilValue(signalWithCalculatedDistance);
   const setDistance = useSetRecoilState(distanceAtom);
+  const setMapPosition = useSetRecoilState(mapPositionAtom);
   const [isActive, setIsActive] = useState<boolean>(false);
   const [ranges, setRanges] = useState<ranges>({
     0.5: true,
@@ -126,6 +130,16 @@ export const SignalList: FC<Props> = ({ map }) => {
     const curRange = e.target.id;
 
     if (!curRange) return;
+    if (curRange === "me") {
+      const position = {
+        lat: myPosition.lat,
+        lng: myPosition.lng,
+      };
+
+      map.panTo(new window.kakao.maps.LatLng(myPosition.lat, myPosition.lng));
+      setMapPosition(position);
+      return;
+    }
 
     const prevRange = Object.keys(ranges).find(range => ranges[range]);
 
@@ -159,6 +173,7 @@ export const SignalList: FC<Props> = ({ map }) => {
             {Object.keys(ranges).sort((a, b) => Number(a) - Number(b)).map(range => 
             <RangeItem id={range} isClicked={ranges[range]} key={range}>{range}km</RangeItem>
             )}
+            <span id="me"></span>
           </RangesBox>
         </ListHeader>
         <ListMain>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import '../styles/globals.css'
 import type { AppProps } from 'next/app'
 import { Global } from '@emotion/react'
 import global from "../styles/global";
+import { RecoilRoot } from 'recoil';
 
 declare global {
   interface Window {
@@ -11,10 +12,10 @@ declare global {
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <>
+    <RecoilRoot>
       <Global styles={global} />
       <Component {...pageProps} />
-    </>
+    </RecoilRoot>
   )
 }
 

--- a/pages/api/signal.ts
+++ b/pages/api/signal.ts
@@ -38,7 +38,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<any>
 ) {
-  const myPosition = await JSON.parse(req.body);
+  const standardPosition = await JSON.parse(req.body);
   const mapData = await getMapData(); // 현재 위치에서 주변에 있는 위도 경도 가져옴.
   const signalPhase = await getSignalPhaseData(); // signal phase info
   const signalTiming = await getSignalTimingData();
@@ -49,7 +49,7 @@ export default async function handler(
       lng: data.mapCtptIntLot / 10000000,
     }
 
-    if (getDistance(myPosition, signalPosition) < 20) {
+    if (getDistance(standardPosition, signalPosition) <= 2) {
       const phase = signalPhase.find((signal: any) => signal.itstId === data.itstId);
       const timing = signalTiming.find((signal: any) => signal.itstId === data.itstId);
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,71 +1,17 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import { useEffect, useState } from 'react'
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import SignalList from '../Components/SignalList';
-import placeSignal from '../utils/placeSignal';
-
-interface position {
-  lat: number,
-  lng: number,
-}
-
-interface phase {
-  [index: string]: string
-}
-
-interface timing {
-  [index: string]: number
-}
-
-interface signal {
-  title: string,
-  timing: {[index: string]: number},
-  phase: {[index: string]: string},
-  latlng: {La: number, Ma: number}
-}
+import myPositionAtom from '../recoil/myPosition/atom';
+import aroundSignalsAtom from '../recoil/aroundSignals/atom';
+import filterSignals from '../utils/filterSignals';
 
 const Home: NextPage = () => {
-  const [mapLoaded, setMapLoaded] = useState<Boolean>(false);
+  const [myPosition, setMyPosition] = useRecoilState(myPositionAtom);
+  const setAroundSignals = useSetRecoilState(aroundSignalsAtom);
+  const [mapLoaded, setMapLoaded] = useState<boolean>(false);
   const [map, setMap] = useState();
-  const [myPosition, setMyPosition] = useState<position>({lat:33.450701, lng: 126.570667});
-  const [aroundPositions, setAroundPositions] = useState<position[]>([]);
-  const [filteredSignals, setFilteredSignals] = useState<signal[]>([]);
-
-  useEffect(() => {
-    if (!aroundPositions.length) return;
-
-    const positions = aroundPositions.map((position: any) => {
-      const phase: phase = {};
-      const timing: timing = {};
-
-      position.phase && Object.keys(position.phase).forEach(key => {
-        if (position.phase[key] && key.includes("Pdsg")) {
-          phase[key] = position.phase[key];
-        }
-      });
-
-      position.timing && Object.keys(position.timing).forEach(key => {
-        if (position.timing[key] && key.includes("Pdsg")) {
-          timing[key] = position.timing[key];
-        }
-      });
-
-      return {
-        title: position.itstNm,
-        latlng: new window.kakao.maps.LatLng(position.lat, position.lng),
-        phase,
-        timing,
-      }
-    });
-
-    positions.forEach(position => {
-      Object.keys(position.phase).forEach(direction => {
-        placeSignal(position, direction, position.phase[direction], map);
-      });
-    });
-
-    setFilteredSignals(positions);
-  }, [aroundPositions]);
 
   useEffect(() => {
     async function getData() {
@@ -75,12 +21,41 @@ const Home: NextPage = () => {
       });
       const response = await data.json();
 
-      setAroundPositions(response);
+      if (!response.length) return;
+
+      const filteredSignals = filterSignals(response);
+
+      setAroundSignals(filteredSignals as any);
     }
 
     getData();
   }, [myPosition]);
   
+  useEffect(() => {
+    if (!mapLoaded) return;
+
+    new window.kakao.maps.load(() => {
+      const container = document.querySelector("#map");
+      const options = {
+        center: new window.kakao.maps.LatLng(myPosition.lat, myPosition.lng),
+			  level: 2
+      };
+      const map = new window.kakao.maps.Map(container, options);
+
+      map.panTo(new window.kakao.maps.LatLng(myPosition.lat, myPosition.lng));
+
+      const gpsContent = `<div id="me"></div>`;
+      const currentOverlay = new window.kakao.maps.CustomOverlay({
+          position: new window.kakao.maps.LatLng(myPosition.lat, myPosition.lng),
+          content: gpsContent,
+          map: map
+      });
+
+      currentOverlay.setMap(map);
+      setMap(map);
+    });
+  }, [mapLoaded, myPosition.lat, myPosition.lng]);
+
   useEffect(() => {
     navigator.geolocation.getCurrentPosition((pos) => {
       const cord = pos.coords;
@@ -104,31 +79,6 @@ const Home: NextPage = () => {
     document.head.append(script);
   }, []);
 
-  useEffect(() => {
-    if (!mapLoaded) return;
-
-    new window.kakao.maps.load(() => {
-      const container = document.querySelector("#map");
-      const options = {
-        center: new window.kakao.maps.LatLng(myPosition.lat, myPosition.lng),
-			  level: 2
-      };
-      const map = new window.kakao.maps.Map(container, options);
-
-      map.panTo(new window.kakao.maps.LatLng(myPosition.lat, myPosition.lng));
-
-      const gpsContent = `<div id="me"></div>`;
-      const currentOverlay = new window.kakao.maps.CustomOverlay({
-          position: new window.kakao.maps.LatLng(myPosition.lat, myPosition.lng),
-          content: gpsContent,
-          map: map
-      });
-      currentOverlay.setMap(map);
-      setMap(map);
-    });
-
-  }, [mapLoaded, myPosition.lat, myPosition.lng]);
-
   return (
     <div>
       <Head>
@@ -138,7 +88,7 @@ const Home: NextPage = () => {
       </Head>
 
       <div id="map" style={{ width: "100vw", height: "100vh"}}></div>
-      <SignalList signals={filteredSignals} />
+      <SignalList map={map} />
     </div>
   )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,18 +4,20 @@ import { useEffect, useState } from 'react'
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import SignalList from '../Components/SignalList';
 import myPositionState from '../recoil/myPosition/atom';
-import { aroundSignalsAtom } from '../recoil/aroundSignals/atom';
+import { aroundSignalsAtom, mapAroundSignalsAtom } from '../recoil/aroundSignals/atom';
 import filterSignals from '../utils/filterSignals';
 import mapPositionAtom from '../recoil/mapPosition/atom';
 import getDistance from '../utils/getDistance';
 import mapMovingAtom from '../recoil/mapMoving/atom';
 import getSignalData from '../utils/getSignalData';
 import placeSignal from '../utils/placeSignal';
+import removeSignals from '../utils/removeSignal';
 
 const Home: NextPage = () => {
   const [myPosition, setMyPosition] = useRecoilState(myPositionState);
   const [mapPosition, setMapPosition] = useRecoilState(mapPositionAtom);
   const [isMapMoving, setIsMapMoving] = useRecoilState(mapMovingAtom);
+  const [mapAroundSignals, setMapAroundSignals] = useRecoilState(mapAroundSignalsAtom);
   const setAroundSignals = useSetRecoilState(aroundSignalsAtom);
   const [mapLoaded, setMapLoaded] = useState<boolean>(false);
   const [map, setMap] = useState();
@@ -33,14 +35,20 @@ const Home: NextPage = () => {
       const response = await getSignalData(mapPosition);
 
       if (!response.length) return;
+      if (mapAroundSignals.length) removeSignals(mapAroundSignals);
 
       const filteredSignals = filterSignals(response);
+      const newPlacedSignals: any[] = [];
 
       filteredSignals.forEach((position: any) => {
         Object.keys(position.phase).forEach(direction => {
-          placeSignal(position, direction, position.phase[direction], map);
+          const point = placeSignal(position, direction, position.phase[direction], map);
+
+          newPlacedSignals.push(point);
         });
       });
+
+      setMapAroundSignals(newPlacedSignals);
     })();
   }, [isMapMoving, mapPosition]);
 
@@ -97,7 +105,7 @@ const Home: NextPage = () => {
       const newPosition = {
         lat: cord.latitude,
         lng: cord.longitude,
-      }
+      };
 
       setMyPosition(newPosition);
     }, (err) => {
@@ -128,4 +136,4 @@ const Home: NextPage = () => {
   )
 }
 
-export default Home
+export default Home;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,13 +29,17 @@ const Home: NextPage = () => {
   }, [mapPosition]);
 
   useEffect(() => {
-    if (!isMapMoving) return;
+    if (!isMapMoving) {
+      mapAroundSignals.length && removeSignals(mapAroundSignals);
+      setMapAroundSignals([]);
+
+      return;
+    }
 
     (async() => {
       const response = await getSignalData(mapPosition);
 
       if (!response.length) return;
-      if (mapAroundSignals.length) removeSignals(mapAroundSignals);
 
       const filteredSignals = filterSignals(response);
       const newPlacedSignals: any[] = [];
@@ -48,6 +52,7 @@ const Home: NextPage = () => {
         });
       });
 
+      mapAroundSignals.length && removeSignals(mapAroundSignals);
       setMapAroundSignals(newPlacedSignals);
     })();
   }, [isMapMoving, mapPosition]);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,12 +3,12 @@ import Head from 'next/head'
 import { useEffect, useState } from 'react'
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import SignalList from '../Components/SignalList';
-import myPositionAtom from '../recoil/myPosition/atom';
-import aroundSignalsAtom from '../recoil/aroundSignals/atom';
+import myPositionState from '../recoil/myPosition/atom';
+import { aroundSignalsAtom } from '../recoil/aroundSignals/atom';
 import filterSignals from '../utils/filterSignals';
 
 const Home: NextPage = () => {
-  const [myPosition, setMyPosition] = useRecoilState(myPositionAtom);
+  const [myPosition, setMyPosition] = useRecoilState(myPositionState);
   const setAroundSignals = useSetRecoilState(aroundSignalsAtom);
   const [mapLoaded, setMapLoaded] = useState<boolean>(false);
   const [map, setMap] = useState();

--- a/recoil/aroundSignals/atom.ts
+++ b/recoil/aroundSignals/atom.ts
@@ -2,12 +2,19 @@ import { atom } from "recoil";
 
 const aroundSignalsAtom = atom({
   key: "aroundSignals",
-  default: []
+  default: [],
+  dangerouslyAllowMutability: true,
 });
 
-const distanceAtom = atom({
+const distanceAtom = atom<number>({
   key: "distanceAtom",
   default: 0.5,
 });
 
-export { aroundSignalsAtom, distanceAtom };
+const mapAroundSignalsAtom = atom<any[]>({
+  key: "mapAroundSignals",
+  default: [],
+  dangerouslyAllowMutability: true,
+});
+
+export { aroundSignalsAtom, distanceAtom, mapAroundSignalsAtom };

--- a/recoil/aroundSignals/atom.ts
+++ b/recoil/aroundSignals/atom.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const aroundSignalsAtom = atom({
+  key: "aroundSignals",
+  default: []
+});
+
+export default aroundSignalsAtom;

--- a/recoil/aroundSignals/atom.ts
+++ b/recoil/aroundSignals/atom.ts
@@ -5,4 +5,9 @@ const aroundSignalsAtom = atom({
   default: []
 });
 
-export default aroundSignalsAtom;
+const distanceAtom = atom({
+  key: "distanceAtom",
+  default: 0.5,
+});
+
+export { aroundSignalsAtom, distanceAtom };

--- a/recoil/aroundSignals/withCalculated.ts
+++ b/recoil/aroundSignals/withCalculated.ts
@@ -10,8 +10,6 @@ const signalWithCalculatedDistance = selector({
     const myPosition = get(myPositionState);
     const signals = get(aroundSignalsAtom);
     const distance = get(distanceAtom);
-
-    const calculatedDistanceSignals = [];
     
     return signals.filter((signal: signal) => {
       const signalPosition = {

--- a/recoil/aroundSignals/withCalculated.ts
+++ b/recoil/aroundSignals/withCalculated.ts
@@ -1,0 +1,27 @@
+import { selector } from "recoil";
+import { aroundSignalsAtom, distanceAtom } from "./atom";
+import myPositionState from '../myPosition/atom';
+import getDistance from '../../utils/getDistance';
+import { signal } from '../../Components/SignalList';
+
+const signalWithCalculatedDistance = selector({
+  key: "calcultedDistanceSignals",
+  get: ({ get }) => {
+    const myPosition = get(myPositionState);
+    const signals = get(aroundSignalsAtom);
+    const distance = get(distanceAtom);
+
+    const calculatedDistanceSignals = [];
+    
+    return signals.filter((signal: signal) => {
+      const signalPosition = {
+        lat: signal.latlng.Ma,
+        lng: signal.latlng.La
+      };
+
+      if (getDistance(myPosition, signalPosition) <= distance) return signal;
+    });
+  }
+});
+
+export default signalWithCalculatedDistance;

--- a/recoil/mapMoving/atom.ts
+++ b/recoil/mapMoving/atom.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil"
+
+const mapMovingAtom = atom({
+  key: "mapMoving",
+  default: false,
+});
+
+export default mapMovingAtom;

--- a/recoil/mapPosition/atom.ts
+++ b/recoil/mapPosition/atom.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const mapPositionAtom = atom({
+  key: "mapPosition",
+  default: {lat:33.450701, lng: 126.570667},
+});
+
+export default mapPositionAtom;

--- a/recoil/myPosition/atom.ts
+++ b/recoil/myPosition/atom.ts
@@ -1,8 +1,8 @@
 import { atom } from "recoil";
 
-const myPositionAtom = atom({
+const myPositionState = atom({
   key: "myPosition",
   default: {lat:33.450701, lng: 126.570667},
 });
 
-export default myPositionAtom;
+export default myPositionState;

--- a/recoil/myPosition/atom.ts
+++ b/recoil/myPosition/atom.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const myPositionAtom = atom({
+  key: "myPosition",
+  default: {lat:33.450701, lng: 126.570667},
+});
+
+export default myPositionAtom;

--- a/utils/filterSignals.ts
+++ b/utils/filterSignals.ts
@@ -1,0 +1,43 @@
+interface phase {
+  [index: string]: string
+}
+
+interface timing {
+  [index: string]: number
+}
+
+interface signal {
+  itstNm: string,
+  lat: number, 
+  lng: number, 
+  phase: phase, 
+  timing: timing
+}
+
+export default function filterSignals(signals: signal[]) {
+  const filteredSignals = signals.map((position: signal) => {
+    const phase: phase = {};
+    const timing: timing = {};
+
+    position.phase && Object.keys(position.phase).forEach(key => {
+      if (position.phase[key] && key.includes("Pdsg")) {
+        phase[key] = position.phase[key];
+      }
+    });
+
+    position.timing && Object.keys(position.timing).forEach(key => {
+      if (position.timing[key] && key.includes("Pdsg")) {
+        timing[key] = position.timing[key];
+      }
+    });
+
+    return {
+      title: position.itstNm,
+      latlng: new window.kakao.maps.LatLng(position.lat, position.lng),
+      phase,
+      timing,
+    }
+  });
+
+  return filteredSignals;
+}

--- a/utils/getDistance.ts
+++ b/utils/getDistance.ts
@@ -1,4 +1,4 @@
-interface position {
+export interface position {
   lat: number,
   lng: number,
 }

--- a/utils/getSignalData.ts
+++ b/utils/getSignalData.ts
@@ -1,0 +1,13 @@
+interface position {
+  lat: number,
+  lng: number,
+}
+
+export default async function getSignalData(position: position) {
+  const data = await fetch("http://localhost:3000/api/signal", {
+    method: "POST",
+    body: JSON.stringify(position),
+  });
+
+  return data.json();
+}

--- a/utils/placeSignal.ts
+++ b/utils/placeSignal.ts
@@ -71,4 +71,6 @@ export default function placeSignal(position: position, direction: string, phase
   });
 
   point.setMap(map);
+
+  return point;
 }

--- a/utils/removeSignal.ts
+++ b/utils/removeSignal.ts
@@ -1,0 +1,7 @@
+const removeSignals = (signals: any[]) => {
+  signals.forEach((signal: any) => {
+    signal.setMap(null);
+  });
+}
+
+export default removeSignals;


### PR DESCRIPTION
## Completed
* Recoil 도입으로 전역상태 관리
  * 현재 전역 상태 관리
    * myPosition
    * mapPosition
    * isMapMoving
    * aroundSignals   
* 유저 위치로 이동하는 버튼 구현


## 문제해결 및 고민

* 지도 중심 주변 2km만 신호정보를 나타내는 것을 구현할때(지도로 움직이는 상황)
  * Recoil에 저장되어 있는 mapAroundSignals 배열값을 업데이트하려고 할때마다 에러가 생겼다.
  * 에러를 읽어보고 찾아보니 불변값을 변경하려고 할때 생기는 에러였다.
  * Recoil state를 setRecoilState를 이용해서 변경했고 다른 곳에서도 문제가 없었는데, 디버깅해보니 setMapAroundSignals로 배열을 교체하려고 할 때  문제가 계속 생겼다.
  * 관련해서 찾아보니 Recoil에 저장된 Object값은 default로 frozen해둔다.
  * 그 이유는 Recoil의 모든 상태 변경이 데이터 흐름 그래프를 통해 업데이트로 표시되고 전파 되도록하는데 저장된 값이 변이를 일으켜 변경을 시도하면 이를 추적하거나 업데이트 되지 않는 경우들이 발생하기 때문이다.
  * 해결 방법은 깊은 복사를 하거나 atom option에 dangerouslyAllowMutability를 true로 설정해두는 방법이 있었다.
  * UNSTABLE한 option이 아니라서 해당 옵션을 true로 변경해서 해결했다.
  * 참고 레퍼런스
    *  https://github.com/facebookexperimental/Recoil/issues/299
    * https://github.com/facebookexperimental/Recoil/issues/406

## 진행 상황

https://user-images.githubusercontent.com/78673049/189518637-a59f53bf-ab38-4a8b-8c5f-c6cbff0c9e32.mov


