### PR TITLE
refactor 🧹: React-Query 도입, feat ✨: Signal List Detail 컴포넌트 구현 및 타이머 설정

### DIFF
--- a/Components/SignalDetail.tsx
+++ b/Components/SignalDetail.tsx
@@ -1,0 +1,44 @@
+import { FC, useState, useEffect } from "react";
+import { translatePhase } from "../utils/signalUtils";
+import { useRecoilValue } from 'recoil';
+import updatedTimeAtom from '../recoil/updatedTime/atom';
+import styled from '@emotion/styled';
+
+const SignalInfomation = styled.div``;
+
+interface Props {
+  direction: string,
+  phase: string,
+  timing: number,
+}
+
+export const SignalDetail: FC<Props> = ({direction, phase, timing}) => {
+  const [isStopSign, setIsStopSign] = useState<boolean>(translatePhase(phase));
+  const [time, setTime] = useState<number | "정보 없음">(timing);
+  const updatedTime = useRecoilValue(updatedTimeAtom);
+
+  useEffect(() => {
+    const goneTime = Math.floor((Date.now() - updatedTime) / 1000);
+    const initialTime = time as number - goneTime;
+    const timer = setInterval(() => {
+      setTime(prev => {
+        if (prev === initialTime + goneTime) return initialTime - 1 > 0 ? initialTime - 1 : 0;
+        if (prev > 0) return prev as number - 1;
+  
+        clearInterval(timer);
+        setIsStopSign(!isStopSign);
+
+        return "정보 없음";
+      });
+    }, 1000);
+  }, []);
+
+  return (
+    <SignalInfomation>
+      <span key={direction + timing}>{direction} {time} {Number.isInteger(time) ? "초" : ""}</span>
+      <span key={direction + phase}>{isStopSign ? "🔴" : "🟢"}</span>
+    </SignalInfomation>
+    )
+};
+
+export default SignalDetail;

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false,
   swcMinify: true,
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,6 +3,7 @@ import type { AppProps } from 'next/app'
 import { Global } from '@emotion/react'
 import global from "../styles/global";
 import { RecoilRoot } from 'recoil';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 declare global {
   interface Window {
@@ -10,12 +11,16 @@ declare global {
   }
 }
 
+const queryClient = new QueryClient();
+
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <RecoilRoot>
-      <Global styles={global} />
-      <Component {...pageProps} />
-    </RecoilRoot>
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <Global styles={global} />
+        <Component {...pageProps} />
+      </RecoilRoot>
+    </QueryClientProvider>
   )
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -107,14 +107,15 @@ const Home: NextPage = () => {
   useEffect(() => {
     navigator.geolocation.getCurrentPosition((pos) => {
       const cord = pos.coords;
-      const newPosition = {
-        lat: cord.latitude,
-        lng: cord.longitude,
-      };
       // const newPosition = {
-      //   lat: 37.57814842135318,
-      //   lng: 126.88837721721241,
-      // } dmc position
+      //   lat: cord.latitude,
+      //   lng: cord.longitude,
+      // };
+      const newPosition = {
+        lat: 37.57814842135318,
+        lng: 126.88837721721241,
+      };
+      //dmc position
 
       setMyPosition(newPosition);
     }, (err) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -111,6 +111,10 @@ const Home: NextPage = () => {
         lat: cord.latitude,
         lng: cord.longitude,
       };
+      // const newPosition = {
+      //   lat: 37.57814842135318,
+      //   lng: 126.88837721721241,
+      // } dmc position
 
       setMyPosition(newPosition);
     }, (err) => {

--- a/recoil/aroundSignals/withCalculated.ts
+++ b/recoil/aroundSignals/withCalculated.ts
@@ -10,7 +10,7 @@ const signalWithCalculatedDistance = selector({
     const myPosition = get(myPositionState);
     const signals = get(aroundSignalsAtom);
     const distance = get(distanceAtom);
-    
+
     return signals.filter((signal: signal) => {
       const signalPosition = {
         lat: signal.latlng.Ma,
@@ -19,7 +19,7 @@ const signalWithCalculatedDistance = selector({
 
       if (getDistance(myPosition, signalPosition) <= distance) return signal;
     });
-  }
+  },
 });
 
 export default signalWithCalculatedDistance;

--- a/recoil/mapPosition/atom.ts
+++ b/recoil/mapPosition/atom.ts
@@ -2,7 +2,7 @@ import { atom } from "recoil";
 
 const mapPositionAtom = atom({
   key: "mapPosition",
-  default: {lat:33.450701, lng: 126.570667},
+  default: {lat: 37.666504, lng: 126.7500495},
 });
 
 export default mapPositionAtom;

--- a/recoil/myPosition/atom.ts
+++ b/recoil/myPosition/atom.ts
@@ -2,7 +2,7 @@ import { atom } from "recoil";
 
 const myPositionState = atom({
   key: "myPosition",
-  default: {lat:33.450701, lng: 126.570667},
+  default: {lat: 37.666504, lng: 126.7500495},
 });
 
 export default myPositionState;

--- a/recoil/updatedTime/atom.ts
+++ b/recoil/updatedTime/atom.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const updatedTimeAtom = atom({
+  key: "updatedTime",
+  default: Date.now(),
+});
+
+export default updatedTimeAtom;

--- a/utils/removeSignal.ts
+++ b/utils/removeSignal.ts
@@ -1,3 +1,4 @@
+// signals는 point map에서 사용하는
 const removeSignals = (signals: any[]) => {
   signals.forEach((signal: any) => {
     signal.setMap(null);

--- a/utils/signalUtils.ts
+++ b/utils/signalUtils.ts
@@ -1,40 +1,40 @@
 export function translatePhase(phase: string) {
-  if (phase.includes("stop")) return "🔴";
-  return "🟢";
+  if (phase.includes("stop")) return true;
+  return false;
 }
 
-export function translateDirection(direction: string, timing: {[index: string]: number}) {
+export function analyzeDirectionAndTime(direction: string, timing: {[index: string]: number}): [string, number] {
   if (direction.includes("nt")) {
-    return `북쪽 ${Math.floor(timing["ntPdsgRmdrCs"] / 10)}초`;
+    return ["북쪽", Math.floor(timing["ntPdsgRmdrCs"] / 10)];
   }
 
   if (direction.includes("et")) {
-    return `동쪽 ${Math.floor(timing["etPdsgRmdrCs"] / 10)}초`;
+    return ["동쪽", Math.floor(timing["etPdsgRmdrCs"] / 10)];
   }
 
   if (direction.includes("st")) {
-    return `남쪽 ${Math.floor(timing["stPdsgRmdrCs"] / 10)}초`;
+    return ["남쪽", Math.floor(timing["stPdsgRmdrCs"] / 10)];
   }
 
   if (direction.includes("wt")) {
-    return `서쪽 ${Math.floor(timing["wtPdsgRmdrCs"] / 10)}초`;
+    return ["서쪽", Math.floor(timing["wtPdsgRmdrCs"] / 10)];
   }
 
   if (direction.includes("ne")) {
-    return `북동쪽 ${Math.floor(timing["nePdsgRmdrCs"] / 10)}초`;
+    return ["북동쪽", Math.floor(timing["nePdsgRmdrCs"] / 10)];
   }
 
   if (direction.includes("nw")) {
-    return `북서쪽 ${Math.floor(timing["nwPdsgRmdrCs"] / 10)}초`;
+    return ["북서쪽", Math.floor(timing["nwPdsgRmdrCs"] / 10)];
   }
 
   if (direction.includes("se")) {
-    return `남동쪽 ${Math.floor(timing["sePdsgRmdrCs"] / 10)}초`;
+    return ["남동쪽", Math.floor(timing["sePdsgRmdrCs"] / 10)];
   }
 
   if (direction.includes("sw")) {
-    return `남서쪽 ${Math.floor(timing["swPdsgRmdrCs"] / 10)}초`;
+    return ["남서쪽", Math.floor(timing["swPdsgRmdrCs"] / 10)];
   }
 
-  return "정보 없음";
+  return ["", 0];
 }


### PR DESCRIPTION
## Completed 🎉

* React Query 도입해서 90초마다 refetch하도록 설정
* Signal List Detail 컴포넌트 구현
  * timer 구현해서 count down

## 문제해결 및 고민 🧗
* React Query refetchInterval 주기
  * 처음에는 가져온 신호등 정보에서 제일 최소 시간을 기준으로 refetch를 계속 하려고 했다.
  * 그렇게 구현할 경우, 너무 자주 fetch가 일어나서 api 요청횟수가 금방 초과될 것 같다.
  * 고민끝에 90초 마다 refetchInterval을 설정했다.
  * 그리고 처음 시간을 받아왔을 때 countDown이 다 됐다면 phase를 변경시켜주고 시간을 정보없음으로 나타냈다.
 
* countDown 구현
  * Detail Component가 mount된 이후에 useEffect에서 setInterval을 사용해서 주어진 시간을 countDown했다.
  * 두가지 문제가 생겼다.
    * 첫째는 range를 변경할때마다 mount돼서 계속 처음 fetch받은 시간부터 countDown됐다.
    * 전역 상태로 fetch받은 updatedTime을 설정해두고, mount됐을 경우 시간과 차이를 구해서, 시간을 뺀 후 부터 countDown으로 문제해결했다.
    * 두번째로는 2초씩 countDown이 됐다.
    * 디버깅을 했을때, react dev tool backend라고 나와서 처음 next.js의 SSR때문에 생긴 문제라고 판단했다.
    * 처음 setInterval을 실행할때, window의 유무를 확인해서 SSR을 막으려고  했다.
    * 로직을 적어도 동일하게 동작했다.
    * dynamic import에서 ssr: false옵션 설정을 한 컴포넌트를 만들어서 적용했지만 해결 못했다.
    * 결국 next.config에서 react strict mode를 false로 바꾸니 해결됐다.
    

## 진행 상황    

https://user-images.githubusercontent.com/78673049/189539844-ce395056-56f8-4ed0-bc64-a3ae009f4acc.mov

