### PR TITLE
fix 🛠: API 요청 에러 핸들링 및 반응형 css 적용

### DIFF
--- a/Components/SignalDetail.tsx
+++ b/Components/SignalDetail.tsx
@@ -4,7 +4,9 @@ import { useRecoilValue } from 'recoil';
 import updatedTimeAtom from '../recoil/updatedTime/atom';
 import styled from '@emotion/styled';
 
-const SignalInfomation = styled.div``;
+const SignalInfomation = styled.div`
+  margin-right: .7rem;
+`;
 
 interface Props {
   direction: string,

--- a/Components/SignalList.tsx
+++ b/Components/SignalList.tsx
@@ -140,7 +140,7 @@ export const SignalList: FC<Props> = ({ map }) => {
       refetchInterval: refetchIntervalTime,
       onSuccess: ( data ) => {
         if (!data.length) setRefetchIntervalTime(false);
-      }
+      },
     }
   );
 

--- a/Components/SignalList.tsx
+++ b/Components/SignalList.tsx
@@ -36,7 +36,7 @@ const ListContainer = styled.div<ContainerProps>`
 `;
 
 const ListMarginTop = styled.div<ContainerMargin>`
-  height: ${(props) => (props.hasSignals ? "70%" : "90%")};
+  height: ${(props) => (props.hasSignals ? "70vh" : "85vh")};
   transition: .5s ease-in-out;
 `;
 
@@ -45,19 +45,19 @@ const List = styled.div`
   background-color: hsla(0,0%,97%,.85882);
   box-shadow: 0 -2px 12px 0 rgb(0 0 0 / 31%);
   pointer-events: all;
-  padding: 10px 3px;
-  margin: 0 4px;
+  padding: 1rem .3rem;
+  margin: 0 .4rem;
 `;
 
 const ListHeader = styled.header`
   display: flex;
   justify-content: space-evenly;
   align-items: center;
-  border-bottom: 1px solid #000;
-  padding: 9px 12px;
+  border-bottom: .1rem solid #000;
+  padding: .9rem 1.2rem;
 
   span {
-    font-size: 28px;
+    font-size: 2rem;
     font-weight: 700;
   }
 `;
@@ -69,8 +69,11 @@ const RangesBox = styled.div`
 `;
 
 const RangeItem = styled.span<RangeItem>`
-  padding: 10px;
-  border-radius: 15px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  border-radius: 1.5rem;
   color: ${(props) => (props.isClicked ? "#ffffff" : "none")};
   background-color: ${(props) => (props.isClicked ? "#00B8FF" : "none")};
   transition: .5s ease-in-out;
@@ -81,22 +84,19 @@ const RangeItem = styled.span<RangeItem>`
 `;
 
 const ListMain = styled.main`
-  padding: 5px 10px;
+  padding: .5rem 1rem;
 `;
 
 const SignalRow = styled.article`
   display: flex;
   align-items: center;
-  height: 55px;
-  border-bottom: 1px solid rgba(0,0,0,.2);
-
-  span {
-    margin-right: 10px;
-  }
+  height: 5rem;
+  border-bottom: .1rem solid rgba(0,0,0,.2);
 `;
 
 const SignalTitle = styled.span`
-  font-size: 20px;
+  margin-right: 1rem;
+  font-size: 1.7rem;
   font-weight: 500;
 `;
 

--- a/pages/api/signal.ts
+++ b/pages/api/signal.ts
@@ -42,6 +42,7 @@ const getSignalTimingData = async () => {
 
     return response;
   }
+
   const result = await fetch(process.env.NEXT_PUBLIC_SIGNAL_TIMING as string);
   const response = await result.json();
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,8 @@ import type { NextPage } from 'next'
 import Head from 'next/head'
 import { useEffect, useState } from 'react'
 import { useRecoilState, useRecoilValue } from 'recoil';
-import SignalList from '../Components/SignalList';
+import { useQuery } from 'react-query';
+import SignalList, { signal } from '../Components/SignalList';
 import filterSignals from '../utils/filterSignals';
 import getDistance from '../utils/getDistance';
 import getSignalData from '../utils/getSignalData';
@@ -12,8 +13,6 @@ import myPositionState from '../recoil/myPosition/atom';
 import mapPositionAtom from '../recoil/mapPosition/atom';
 import mapMovingAtom from '../recoil/mapMoving/atom';
 import { mapAroundSignalsAtom } from '../recoil/aroundSignals';
-import { useQuery } from 'react-query';
-import { signal }from "../Components/SignalList";
 
 const Home: NextPage = () => {
   const myPosition = useRecoilValue(myPositionState);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -41,6 +41,19 @@ table {
 	border-collapse: collapse;
 	border-spacing: 0;
 }
+:root {
+	font-size: 0.5em;
+}
+@media (min-width: 800px) {
+	:root {
+		font-size: 0.875em;
+	}
+}
+@media (min-width: 1200px) {
+	:root {
+		font-size: 1em;
+	}
+}
 
 #me {
 	width: 15px;

--- a/utils/getSignalData.ts
+++ b/utils/getSignalData.ts
@@ -9,5 +9,5 @@ export default async function getSignalData(position: position) {
     body: JSON.stringify(position),
   });
 
-  return data.json();
+  return data.ok ? data.json() : [];
 }


### PR DESCRIPTION
## Completed

* API 하루 요청 제한 초과시 500에러 발생
  * response.ok 가 false일때, 빈배열을 반환하도록 변경
  * 실제로 API가 불안정해서 응답값 빈배열일 경우랑 동일하게 처리하기 편리하다고 판단
  * 추후 응답에 따른 에러 상황 나눌지 고민 (현재는 api요청 초과밖에 없다고 판단해서 빈배열로 반환하는게 많은 상황에 대응할 수 있다고 생각)

* 반응형 CSS 적용
  *  모바일에서 사용할때, List 컴포넌트 글자가 겹쳐보임
  * 반응형 적용해서 root font-size기준으로 rem설정으로 모바일 반응형 적용
<img width="613" alt="스크린샷 2022-09-12 오후 10 53 17" src="https://user-images.githubusercontent.com/78673049/189672100-acb2e991-80e5-4ee9-b266-e4ff06c357c7.png">

